### PR TITLE
Playsinline arjs webcam texture

### DIFF
--- a/aframe/build/aframe-ar-nft.js
+++ b/aframe/build/aframe-ar-nft.js
@@ -4620,6 +4620,7 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.scene.renderer.autoClear = false;
         this.video = document.createElement("video");
         this.video.setAttribute("autoplay", true);
+        this.video.setAttribute("playsinline", true);
         this.video.setAttribute("display", "none");
         document.body.appendChild(this.video);
         this.geom = new THREE.PlaneBufferGeometry(); //0.5, 0.5);

--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -5970,6 +5970,7 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.scene.renderer.autoClear = false;
         this.video = document.createElement("video");
         this.video.setAttribute("autoplay", true);
+        this.video.setAttribute("playsinline", true);
         this.video.setAttribute("display", "none");
         document.body.appendChild(this.video);
         this.geom = new THREE.PlaneBufferGeometry(); //0.5, 0.5);

--- a/aframe/src/location-based/arjs-webcam-texture.js
+++ b/aframe/src/location-based/arjs-webcam-texture.js
@@ -8,6 +8,7 @@ AFRAME.registerComponent('arjs-webcam-texture', {
         this.scene.renderer.autoClear = false;
         this.video = document.createElement("video");
         this.video.setAttribute("autoplay", true);
+        this.video.setAttribute("playsinline", true);
         this.video.setAttribute("display", "none");
         document.body.appendChild(this.video);
         this.geom = new THREE.PlaneBufferGeometry(); //0.5, 0.5);


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->
**What kind of change does this PR introduce?**
Bugfix.

**Can it be referenced to an Issue? If so what is the issue # ?**
None that I'm aware of.

**How can we test it?**
I noticed this issue when testing the "basic example" of the peakfinder tutorial.
- Fixed: [Here is a version loading aframe-ar-nft.js from my PR](https://gist.githack.com/stevenlybeck/c572cbe128afd6ecd17129b3195494a6/raw/8d90a530b87c0c542cf3bc4acfbb6109adcc7cec/peakfinder-basic-with-fix.html)
- Not fixed: [Here is a version loading aframe-ar-nft.js from the dev branch](https://gist.githack.com/stevenlybeck/c572cbe128afd6ecd17129b3195494a6/raw/8d90a530b87c0c542cf3bc4acfbb6109adcc7cec/peakfinder-basic-without-fix.html)

**Summary**
Adding `webcam; videoTexture: true;` to the `arjs` attribute of an `<a-scene>` tag would result in showing only a single still frame on iOS devices.

This is because by default, HTML <video> elements are paused in iOS unless they are visible full screen. iOS allows the video element to play in non-fullscreen mode by adding the `playsinline` attribute.

**Does this PR introduce a breaking change?**
No API changes.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Tested the two links above on Chrome/Mac, Firefox/Mac and Safari/iOS 14.4.2.

